### PR TITLE
fix: commitlint to use 16.15.1 to fix optional deps

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "16.15.1"
       - run: npm install commitlint-plugin-function-rules
       - uses: wagoid/commitlint-github-action@v3
         env:


### PR DESCRIPTION
older node version is ignore esbuild optional deps and trying to install the wrong platform:
https://github.com/agblox/meetingmap-frontend/actions/runs/3107905706/jobs/5036521907

Reference:
https://github.com/evanw/esbuild/issues/1707#issuecomment-951155267

Updating to use the node version we use locally is a good idea.